### PR TITLE
v1.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [1.0.9] - 2025-01-14
+
+### Fix
+- [Extension] Transform.DestroyAllChildren will loop to dead. It's cause Editor is not updating the Transform.childCount on child destroyed.
+
 ## [1.0.8] - 2025-01-13
 
 ### Add

--- a/Runtime/Extensions/Extensions.Transform.cs
+++ b/Runtime/Extensions/Extensions.Transform.cs
@@ -13,9 +13,12 @@ namespace AceLand.Library.Extensions
         
         public static void DestroyAllChildren(this Transform transform)
         {
-            while (transform.childCount > 0)
+            var children = new List<GameObject>();
+            for (int i = 0; i < transform.childCount; i++)
+                children.Add(transform.GetChild(i).gameObject);
+
+            foreach (var child in children)
             {
-                var child = transform.GetChild(0).gameObject;
                 if (Application.isPlaying) Object.Destroy(child);
                 else Object.DestroyImmediate(child);
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.aceland.library",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "displayName": "AceLand Library",
   "description": "AceLand Library is utilities, editor extension, unity low-level tools, c# and unity implements.\n\nPlease visit our [Git Book](https://aceland-workshop.gitbook.io/aceland-unity-packages).",
   "unity": "2022.3",


### PR DESCRIPTION
fixed Transform.DestroyAllChildren will loop to dead. It's cause Editor is not updating the Transform.childCount on child destroyed.